### PR TITLE
fix(home): add YouTube link next to FSTO resource

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ resources:
 
       - title: Watch
         icon: fa-youtube-play
-        href: http://fstoconf15-videos.fsto.co/
+        href: https://www.youtube.com/watch?v=4r2_MGnE5vM
 
   - title: Discuss @ Github
     link: https://github.com/OpenDevelopmentMethod/discussion


### PR DESCRIPTION
See #3 

The current link goes to a FSTO video player that no longer exists. I found a related video on YouTube that I believe should go here instead.